### PR TITLE
feat: add password-based headless session auth via --username

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,13 +5,15 @@ version = 4
 [[package]]
 name = "account_sdk"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/controller-rs?tag=v0.9.2#99bcc039dcb454af2ef4f50d4e3d347f180940a0"
+source = "git+https://github.com/frontboat/controller-rs?branch=feat%2Fheadless-password-auth#06e9eae4cf26a6d305f7e6282d2c29996d4e1f3a"
 dependencies = [
+ "aes-gcm",
  "alloy-primitives",
  "alloy-signer",
  "anyhow",
  "async-trait",
  "auto_impl",
+ "base64 0.22.1",
  "cainome",
  "cainome-cairo-serde",
  "chrono",
@@ -27,6 +29,7 @@ dependencies = [
  "nom",
  "num-traits",
  "once_cell",
+ "pbkdf2 0.12.2",
  "primitive-types",
  "rand 0.8.5",
  "reqwest 0.11.27",
@@ -58,6 +61,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +79,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -898,6 +925,7 @@ dependencies = [
  "hex",
  "indicatif",
  "reqwest 0.12.28",
+ "rpassword",
  "serde",
  "serde_json",
  "shellexpand",
@@ -1027,6 +1055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1188,7 +1217,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1318,7 +1347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1332,7 +1361,7 @@ dependencies = [
  "digest 0.10.7",
  "hex",
  "hmac",
- "pbkdf2",
+ "pbkdf2 0.11.0",
  "rand 0.8.5",
  "scrypt",
  "serde",
@@ -1600,6 +1629,16 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -2435,7 +2474,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2523,6 +2562,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,6 +2625,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,6 +2648,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+ "password-hash",
+ "sha2",
 ]
 
 [[package]]
@@ -2630,6 +2698,18 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2820,7 +2900,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3096,6 +3176,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ruint"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,7 +3270,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3317,7 +3418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
 dependencies = [
  "hmac",
- "pbkdf2",
+ "pbkdf2 0.11.0",
  "salsa20",
  "sha2",
 ]
@@ -3914,7 +4015,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4428,6 +4529,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4737,7 +4848,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,12 @@ path = "src/main.rs"
 # Local development: use path dependency
 # account_sdk = { path = "../controller-rs/account_sdk", features = ["filestorage"] }
 # Release builds: use git dependency
-account_sdk = { git = "https://github.com/cartridge-gg/controller-rs", tag = "v0.9.2", package = "account_sdk", features = ["filestorage"] }
+# Password auth feature requires the crypto/password/graphql additions from:
+# https://github.com/frontboat/controller-rs/tree/feat/headless-password-auth
+account_sdk = { git = "https://github.com/frontboat/controller-rs", branch = "feat/headless-password-auth", package = "account_sdk", features = ["filestorage"] }
+
+# Password input without echo
+rpassword = "7"
 
 # CLI framework
 clap = { version = "4.5", features = ["derive", "env"] }

--- a/src/commands/session/authorize.rs
+++ b/src/commands/session/authorize.rs
@@ -129,7 +129,16 @@ pub async fn execute(
     overwrite: bool,
     account: Option<&str>,
     expires: &str,
+    username: Option<String>,
 ) -> Result<()> {
+    // If --username is provided, use password-based headless auth
+    if let Some(username) = username {
+        return execute_password_auth(
+            config, formatter, preset, file, chain_id, rpc_url, account, expires, &username,
+        )
+        .await;
+    }
+
     // Validate that either preset or file is provided
     if preset.is_none() && file.is_none() {
         return Err(CliError::InvalidInput(
@@ -680,6 +689,240 @@ fn store_session_from_api(
         .set_controller(&chain_id, address, controller_metadata)
         .map_err(|e| CliError::Storage(e.to_string()))?;
 
+    Ok(())
+}
+
+/// Password-based headless session authorization.
+///
+/// Authenticates via `Controller::from_password()` — decrypts the owner's
+/// encrypted private key from Cartridge's API using the provided password,
+/// creates a session locally, and stores it in the same format as browser-based auth.
+#[allow(clippy::too_many_arguments)]
+async fn execute_password_auth(
+    config: &Config,
+    formatter: &dyn OutputFormatter,
+    preset: Option<String>,
+    file: Option<String>,
+    chain_id: Option<String>,
+    rpc_url: Option<String>,
+    account: Option<&str>,
+    expires: &str,
+    username: &str,
+) -> Result<()> {
+    use account_sdk::controller::Controller;
+    use account_sdk::storage::{StorageBackend, StorageValue};
+
+    // Resolve RPC URL
+    let resolved_rpc_url = if let Some(ref chain_id_str) = chain_id {
+        match chain_id_str.as_str() {
+            "SN_MAIN" => "https://api.cartridge.gg/x/starknet/mainnet".to_string(),
+            "SN_SEPOLIA" => "https://api.cartridge.gg/x/starknet/sepolia".to_string(),
+            _ => {
+                return Err(CliError::InvalidInput(format!(
+                    "Unsupported chain ID '{chain_id_str}'. Supported: SN_MAIN, SN_SEPOLIA"
+                )));
+            }
+        }
+    } else if let Some(ref url) = rpc_url {
+        url.clone()
+    } else if config.session.rpc_url_explicitly_set {
+        config.session.rpc_url.clone()
+    } else {
+        formatter.warning("No --chain-id or --rpc-url specified, using SN_SEPOLIA by default");
+        config.session.rpc_url.clone()
+    };
+
+    // Prompt for password (never a CLI flag — avoid shell history)
+    let password = rpassword::prompt_password("Password: ")
+        .map_err(|e| CliError::InvalidInput(format!("failed to read password: {e}")))?;
+
+    formatter.info(&format!("Authenticating as '{username}'..."));
+
+    // Set storage path so Controller's internal FileSystemBackend uses it
+    let storage_path = config.resolve_storage_path(account);
+    if account.is_some() {
+        std::fs::create_dir_all(&storage_path)
+            .map_err(|e| CliError::Storage(format!("Failed to create account directory: {e}")))?;
+    }
+    std::env::set_var(
+        "CARTRIDGE_STORAGE_PATH",
+        storage_path.to_string_lossy().as_ref(),
+    );
+
+    let rpc_url_parsed = url::Url::parse(&resolved_rpc_url)
+        .map_err(|e| CliError::InvalidInput(format!("Invalid RPC URL: {e}")))?;
+
+    // The SDK's API client appends "/query" internally, so pass the base URL.
+    // The CLI config stores the full URL (e.g. "https://api.cartridge.gg/query"),
+    // but the SDK expects the base (e.g. "https://api.cartridge.gg").
+    let api_base_url = config
+        .session
+        .api_url
+        .strip_suffix("/query")
+        .unwrap_or(&config.session.api_url);
+
+    // Authenticate with password — decrypts owner key, creates Controller
+    let mut controller =
+        Controller::from_password(username, &password, rpc_url_parsed, api_base_url)
+            .await
+            .map_err(|e| CliError::ApiError(format!("authentication failed: {e}")))?;
+
+    formatter.info(&format!(
+        "Authenticated. Controller address: 0x{:x}",
+        controller.address
+    ));
+
+    // Parse expiration
+    let expires_at = parse_expiration(expires)?;
+    formatter.info(&format!("Session expiration: {expires}"));
+
+    // Load policies and create session
+    let policy_file: Option<PolicyFile> = if let Some(preset_name) = preset {
+        let preset_config = crate::presets::fetch_preset(&preset_name).await?;
+
+        let provider = starknet::providers::jsonrpc::JsonRpcClient::new(
+            starknet::providers::jsonrpc::HttpTransport::new(
+                url::Url::parse(&resolved_rpc_url)
+                    .map_err(|e| CliError::InvalidInput(format!("Invalid RPC URL: {e}")))?,
+            ),
+        );
+        let chain_id_felt = starknet::providers::Provider::chain_id(&provider)
+            .await
+            .map_err(|e| CliError::InvalidInput(format!("Failed to query chain_id: {e}")))?;
+        let chain_name = starknet::core::utils::parse_cairo_short_string(&chain_id_felt)
+            .unwrap_or_else(|_| format!("0x{chain_id_felt:x}"));
+
+        let chain_policies =
+            crate::presets::extract_chain_policies(&preset_config, &chain_name, &preset_name)?;
+
+        let contracts = chain_policies
+            .contracts
+            .into_iter()
+            .map(|(addr, contract)| {
+                (
+                    addr,
+                    ContractPolicy {
+                        name: Some(contract.name),
+                        methods: contract
+                            .methods
+                            .into_iter()
+                            .map(|m| MethodPolicy {
+                                name: m.name,
+                                entrypoint: m.entrypoint,
+                                description: m.description,
+                                amount: None,
+                                authorized: true,
+                            })
+                            .collect(),
+                    },
+                )
+            })
+            .collect();
+
+        Some(PolicyFile {
+            contracts,
+            messages: chain_policies.messages,
+        })
+    } else if let Some(file_path) = file {
+        let content = std::fs::read_to_string(&file_path)
+            .map_err(|e| CliError::InvalidInput(format!("Failed to read policy file: {e}")))?;
+        Some(
+            serde_json::from_str(&content)
+                .map_err(|e| CliError::InvalidInput(format!("Invalid policy file: {e}")))?,
+        )
+    } else {
+        None
+    };
+
+    formatter.info("Creating session...");
+
+    if let Some(ref pf) = policy_file {
+        // Build Policy vector (sorted to match frontend canonical ordering)
+        let mut policy_vec = Vec::new();
+        let mut sorted_contracts: Vec<_> = pf.contracts.iter().collect();
+        sorted_contracts.sort_by(|(a, _), (b, _)| a.to_lowercase().cmp(&b.to_lowercase()));
+
+        for (address_str, contract) in &sorted_contracts {
+            let address = starknet::core::types::Felt::from_hex(address_str)
+                .map_err(|e| CliError::InvalidInput(format!("Invalid contract address: {e}")))?;
+
+            let mut sorted_methods = contract.methods.clone();
+            sorted_methods.sort_by(|a, b| a.entrypoint.cmp(&b.entrypoint));
+
+            for method in &sorted_methods {
+                let selector = starknet::core::utils::get_selector_from_name(&method.entrypoint)
+                    .map_err(|e| {
+                        CliError::InvalidInput(format!(
+                            "Invalid entrypoint {}: {e}",
+                            method.entrypoint
+                        ))
+                    })?;
+                policy_vec.push(account_sdk::account::session::policy::Policy::new_call(
+                    address, selector,
+                ));
+            }
+        }
+
+        let total_contracts = pf.contracts.len();
+        let total_entrypoints: usize = pf.contracts.values().map(|c| c.methods.len()).sum();
+        formatter.info(&format!(
+            "Policies: {total_contracts} contracts, {total_entrypoints} entrypoints"
+        ));
+
+        let _session = controller
+            .create_session(policy_vec, expires_at)
+            .await
+            .map_err(|e| CliError::ApiError(format!("Failed to create session: {e}")))?;
+    } else {
+        formatter.warning("No policies specified — creating wildcard session");
+        let _session = controller
+            .create_wildcard_session(expires_at)
+            .await
+            .map_err(|e| CliError::ApiError(format!("Failed to create session: {e}")))?;
+    };
+
+    // Store extra metadata that execute/status commands expect
+    let mut backend =
+        account_sdk::storage::filestorage::FileSystemBackend::new(storage_path.clone());
+
+    // Store controller metadata
+    backend
+        .set_controller(
+            &controller.chain_id,
+            controller.address,
+            account_sdk::storage::ControllerMetadata::from(&controller),
+        )
+        .map_err(|e| CliError::Storage(e.to_string()))?;
+
+    let chain_id_str = starknet::core::utils::parse_cairo_short_string(&controller.chain_id)
+        .unwrap_or_else(|_| format!("0x{:x}", controller.chain_id));
+
+    // Store policies for status command
+    if let Some(ref pf) = policy_file {
+        let policies_storage = PolicyStorage {
+            contracts: pf.contracts.clone(),
+        };
+        let policies_json = serde_json::to_string(&policies_storage)
+            .map_err(|e| CliError::Storage(format!("Failed to serialize policies: {e}")))?;
+        backend
+            .set("session_policies", &StorageValue::String(policies_json))
+            .map_err(|e| CliError::Storage(e.to_string()))?;
+    }
+
+    if config.cli.json_output {
+        formatter.success(&serde_json::json!({
+            "message": "Session authorized via password and stored successfully",
+            "username": username,
+            "address": format!("0x{:x}", controller.address),
+            "chain_id": chain_id_str,
+        }));
+    } else {
+        formatter.info("Session authorized and stored successfully.");
+        formatter.info(&format!("Address: 0x{:x}", controller.address));
+        formatter.info(&format!("Chain: {chain_id_str}"));
+    }
+
+    // Owner key is dropped here
     Ok(())
 }
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,11 +1,5 @@
-use crate::{
-    config::Config,
-    error::{CliError, Result},
-    output::OutputFormatter,
-};
-use account_sdk::storage::{
-    filestorage::FileSystemBackend, Credentials, StorageBackend, StorageValue,
-};
+use crate::{config::Config, error::Result, output::OutputFormatter};
+use account_sdk::storage::{filestorage::FileSystemBackend, StorageBackend, StorageValue};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -108,49 +102,30 @@ pub async fn execute(
                         entries
                     });
 
-                let session_key_guid =
-                    backend
-                        .get("session_key_guid")
-                        .ok()
-                        .flatten()
-                        .and_then(|v| match v {
-                            StorageValue::String(s) => Some(s),
-                            _ => None,
-                        });
+                // Read session key guid and public key from session metadata
+                let guid = format!("0x{:x}", metadata.session.inner.session_key_guid);
 
-                match session_key_guid {
-                    Some(guid) => {
-                        let public_key = match backend.get("session_signer") {
-                            Ok(Some(StorageValue::String(data))) => {
-                                let credentials: Credentials = serde_json::from_str(&data)
-                                    .map_err(|e| CliError::InvalidSessionData(e.to_string()))?;
-                                let signing_key = starknet::signers::SigningKey::from_secret_scalar(
-                                    credentials.private_key,
-                                );
-                                format!("0x{:x}", signing_key.verifying_key().scalar())
-                            }
-                            _ => String::new(),
-                        };
+                let public_key = metadata
+                    .credentials
+                    .as_ref()
+                    .map(|creds| {
+                        let signing_key =
+                            starknet::signers::SigningKey::from_secret_scalar(creds.private_key);
+                        format!("0x{:x}", signing_key.verifying_key().scalar())
+                    })
+                    .unwrap_or_default();
 
-                        Some(SessionInfo {
-                            guid,
-                            public_key,
-                            address,
-                            chain_id,
-                            expires_at,
-                            expires_in_seconds: expires_in,
-                            expires_at_formatted: expires_at_dt
-                                .format("%Y-%m-%d %H:%M:%S UTC")
-                                .to_string(),
-                            is_expired,
-                            policies,
-                        })
-                    }
-                    None => {
-                        formatter.warning("Session data is outdated. Run 'controller session auth' to create a new session.");
-                        None
-                    }
-                }
+                Some(SessionInfo {
+                    guid,
+                    public_key,
+                    address,
+                    chain_id,
+                    expires_at,
+                    expires_in_seconds: expires_in,
+                    expires_at_formatted: expires_at_dt.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+                    is_expired,
+                    policies,
+                })
             }
             _ => None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,6 +390,10 @@ enum SessionCommands {
         /// Defaults to 7days
         #[arg(long, default_value = "7days")]
         expires: String,
+
+        /// Authenticate with password (headless, no browser). Requires --username.
+        #[arg(long)]
+        username: Option<String>,
     },
 
     /// Display current session status and information
@@ -461,6 +465,7 @@ async fn main() {
                 rpc_url,
                 overwrite,
                 expires,
+                username,
             } => {
                 commands::session::authorize::execute(
                     &config,
@@ -472,6 +477,7 @@ async fn main() {
                     overwrite,
                     account.as_deref(),
                     &expires,
+                    username,
                 )
                 .await
             }


### PR DESCRIPTION
## Summary

- Adds `--username` flag to `controller session auth` for password-based headless auth (no browser)
- Supports wildcard sessions when no `--preset` or `--file` is provided
- Refactors `status` command to read from canonical `@cartridge/` storage instead of duplicate loose files

```
controller session auth --username alice --preset my-game --chain-id SN_MAIN
```

Depends on cartridge-gg/controller-rs#101.

## Test plan

- [x] 58/58 existing tests pass
- [x] Clippy clean, rustfmt clean
- [x] End-to-end tested on mainnet (`auth` → `status`)